### PR TITLE
Allow custom PR labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,4 @@ jobs:
 |repo-token|A GitHub token with permission to write issue comments on your repository||true|
 |label|The name of the issue label that indicates that the ADR is accepted. This value is case sensitive!|`ADR: accepted`|false|
 |path|The path in your repor where ADRs should be written.|`docs/architecture/decisions/`|false|
+|pr-label|The label to apply to the created pull reqeust. Set to `true` to re-use the issue label, `false` to not label the pull request, or a string to set a custom label.|`true`|false|

--- a/accepted/action.yaml
+++ b/accepted/action.yaml
@@ -14,6 +14,12 @@ inputs:
       The path in your repo where ADRs should be written. Defaults to
       docs/architecture/decisions/
     default: docs/architecture/decisions/
+  pr-label:
+    description: |
+      The label to apply to the created pull reqeust. Set to true to re-use the
+      issue label, false to not label the pull request, or a string to set a
+      custom label.
+    default: true
   repo-token:
     description: |
       A GitHub token with permission to read and create pull requests on your
@@ -80,6 +86,6 @@ runs:
         git push -f origin $BRANCH
         gh pr create \
           --title "Add ADR ${{ steps.next.outputs.number }} to the repo" \
-          --label "ADR" \
+          ${{ inputs.pr-label == false && '' || '--label "${{ inputs.pr-label == true && inputs.label || inputs.pr-label }}" \' }}
           --body "This pull request was opened automatically because #${{ github.event.issue.number }} was closed after being marked as an approved ADR. It contains a markdown file capturing the ADR body at the time the issue was closed. Please verify that the markdown is correct before merging!" || true
         gh pr merge $BRANCH --auto --squash || true


### PR DESCRIPTION
Adds a `pr-label` input to the ADR acceptance action that allows users to define what label, if any, is applied to pull requests created by the action.

Previous behavior attempted to apply the `ADR` label in all cases and that was not configurable. So that's not great.