### PR TITLE
Auto bump the major version tag on release

### DIFF
--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -1,0 +1,21 @@
+name: On release
+on:
+  release:
+    types: [released]
+
+jobs:
+  update-tags:
+    name: update tags
+    runs-on: ubuntu
+    steps:
+      - name: checkout main branch
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: update the major version tag
+        run: |
+          TAG=${{ github.event.release.tag_name }}
+          MAJOR="$(echo $TAG | sed -r 's/\.[0-9]+\.[0-9]+$//')"
+          git tag -f $MAJOR $TAG
+          git push -f --tags


### PR DESCRIPTION
Adds an automation that runs when a new release is published to create or move a major version tag on the release tag. E.g., if release v1.0.7 is published, this action will move tag v1 to match v1.0.7. This way users can pin to `18f/adr-automation/accepted@v1` and get the semantic equivalent of `^1.0.0`.